### PR TITLE
Enable differential downloads

### DIFF
--- a/src/Service.php
+++ b/src/Service.php
@@ -16,7 +16,7 @@
  *
  * @copyright 2013-present Meplato GmbH.
  * @author Meplato API Team <support@meplato.com>
- * @version 2.1.7
+ * @version 2.1.8
  * @license Copyright (c) 2015-2020 Meplato GmbH. All rights reserved.
  * @link https://developer.meplato.com/store2/#terms Terms of Service
  * @link https://developer.meplato.com/store2/ External documentation
@@ -26,7 +26,7 @@ class Service
 	/** @@var string API title */
 	const TITLE = "Meplato Store API";
 	/** @@var string API version */
-	const VERSION = "2.1.7";
+	const VERSION = "2.1.8";
 	/** @@var string Base URL of the service, including the path */
 	const BASE_URL = "https://store.meplato.com/api/v2";
 	/** @@var string User Agent string that will be sent to the server */

--- a/src/catalogs/Service.php
+++ b/src/catalogs/Service.php
@@ -18,7 +18,7 @@ use Meplato\Store2;
  *
  * @copyright 2013-present Meplato GmbH.
  * @author Meplato API Team <support@meplato.com>
- * @version 2.1.7
+ * @version 2.1.8
  * @license Copyright (c) 2015-2020 Meplato GmbH. All rights reserved.
  * @link https://developer.meplato.com/store2/#terms Terms of Service
  * @link https://developer.meplato.com/store2/ External documentation
@@ -28,7 +28,7 @@ class Service
 	/** @@var string API title */
 	const TITLE = "Meplato Store API";
 	/** @@var string API version */
-	const VERSION = "2.1.7";
+	const VERSION = "2.1.8";
 	/** @@var string Base URL of the service, including the path */
 	const BASE_URL = "https://store.meplato.com/api/v2";
 	/** @@var string User Agent string that will be sent to the server */

--- a/src/jobs/Service.php
+++ b/src/jobs/Service.php
@@ -18,7 +18,7 @@ use Meplato\Store2;
  *
  * @copyright 2013-present Meplato GmbH.
  * @author Meplato API Team <support@meplato.com>
- * @version 2.1.7
+ * @version 2.1.8
  * @license Copyright (c) 2015-2020 Meplato GmbH. All rights reserved.
  * @link https://developer.meplato.com/store2/#terms Terms of Service
  * @link https://developer.meplato.com/store2/ External documentation
@@ -28,7 +28,7 @@ class Service
 	/** @@var string API title */
 	const TITLE = "Meplato Store API";
 	/** @@var string API version */
-	const VERSION = "2.1.7";
+	const VERSION = "2.1.8";
 	/** @@var string Base URL of the service, including the path */
 	const BASE_URL = "https://store.meplato.com/api/v2";
 	/** @@var string User Agent string that will be sent to the server */

--- a/src/products/Service.php
+++ b/src/products/Service.php
@@ -18,7 +18,7 @@ use Meplato\Store2;
  *
  * @copyright 2013-present Meplato GmbH.
  * @author Meplato API Team <support@meplato.com>
- * @version 2.1.7
+ * @version 2.1.8
  * @license Copyright (c) 2015-2020 Meplato GmbH. All rights reserved.
  * @link https://developer.meplato.com/store2/#terms Terms of Service
  * @link https://developer.meplato.com/store2/ External documentation
@@ -28,7 +28,7 @@ class Service
 	/** @@var string API title */
 	const TITLE = "Meplato Store API";
 	/** @@var string API version */
-	const VERSION = "2.1.7";
+	const VERSION = "2.1.8";
 	/** @@var string Base URL of the service, including the path */
 	const BASE_URL = "https://store.meplato.com/api/v2";
 	/** @@var string User Agent string that will be sent to the server */
@@ -470,6 +470,7 @@ class GetService
 	 * - matgroup (string): Matgroup is the material group of the product on the buy-side.
 	 * - meplatoPrice (float64): MeplatoPrice is the Meplato price of the product.
 	 * - merchantId (int64): ID of the merchant.
+	 * - mode (string): Mode is only used for differential downloads and is the type of change of a product (CREATED, UPDATED, DELETED).
 	 * - mpn (string): MPN is the manufacturer part number.
 	 * - multiSupplierId (string): MultiSupplierID represents an optional field for the unique identifier of a supplier in a multi-supplier catalog.
 	 * - multiSupplierName (string): MultiSupplierName represents an optional field for the name of the supplier in a multi-supplier catalog.
@@ -699,6 +700,22 @@ class ScrollService
 	}
 
 	/**
+	 * Mode can be used in combination with version to specify if the result should
+	 * include all products for the specific version of the catalog (full), or just
+	 * the products that changed from the previous version (diff). If the mode is
+	 * "diff", the type of change to the product can be found in the attribute
+	 * "mode" and has the following values: "Created", "Updated", "Deleted". 
+	 *
+	 * @param $mode (string)
+	 * @return $this so that the function is chainable
+	 */
+	function mode($mode)
+	{
+		$this->opt["mode"] = $mode;
+		return $this;
+	}
+
+	/**
 	 * PageToken must be passed in the 2nd and all consective requests to get the
 	 * next page of results. You do not need to pass the page token manually. You
 	 * should just follow the nextUrl link in the metadata to get the next slice of
@@ -730,6 +747,18 @@ class ScrollService
 	}
 
 	/**
+	 * Version of the catalog to be retrieved
+	 *
+	 * @param $version (int64)
+	 * @return $this so that the function is chainable
+	 */
+	function version($version)
+	{
+		$this->opt["version"] = $version;
+		return $this;
+	}
+
+	/**
 	 * Execute the service call.
 	 *
 	 * The return values has the following properties:
@@ -749,10 +778,16 @@ class ScrollService
 		// Parameters (in template and query string)
 		$params = [];
 		$params["area"] = $this->area;
+		if (array_key_exists("mode", $this->opt)) {
+			$params["mode"] = $this->opt["mode"];
+		}
 		if (array_key_exists("pageToken", $this->opt)) {
 			$params["pageToken"] = $this->opt["pageToken"];
 		}
 		$params["pin"] = $this->pin;
+		if (array_key_exists("version", $this->opt)) {
+			$params["version"] = $this->opt["version"];
+		}
 
 		// HTTP Headers
 		$headers = [
@@ -768,7 +803,7 @@ class ScrollService
 			$headers["Authorization"] = "Basic {$credentials}";
 		}
 
-		$urlTemplate = $this->service->getBaseURL() . "/catalogs/{pin}/{area}/products/scroll{?pageToken}";
+		$urlTemplate = $this->service->getBaseURL() . "/catalogs/{pin}/{area}/products/scroll{?pageToken,mode,version}";
 
 		$body = NULL;
 

--- a/tests/mock/responses/products.scroll.differential.success
+++ b/tests/mock/responses/products.scroll.differential.success
@@ -1,0 +1,311 @@
+HTTP/1.1 200 OK
+Cache-Control: private, no-cache
+Content-Type: application/json; charset=utf-8
+Last-Modified: Tue, 31 Mar 2015 14:54:37 GMT
+P3p: CP="This is not a P3P policy!"
+Vary: Cookie
+X-Content-Type-Options: nosniff
+X-Frame-Options: SAMEORIGIN
+X-Ua-Compatible: IE=edge
+X-Xss-Protection: 1; mode=block
+Date: Tue, 31 Mar 2015 14:54:37 GMT
+
+{
+  "kind": "store#products",
+  "selfLink": "https://store2.meplato.com/api/v2/catalogs/AD8CCDD5F9/work/products/scroll?pretty=1\u0026pageToken=c2NhbjsyOzc1OTpFUDU3a3FNelNPdWlzR1dnZFNsTFJBOzc2MDpFUDU3a3FNelNPdWlzR1dnZFNsTFJBOzE7dG90YWxfaGl0czo5ODYyMTs=",
+  "nextLink": "https://store2.meplato.com/api/v2/catalogs/AD8CCDD5F9/work/products/scroll?pageToken=c2NhbjsyOzc1OTpFUDU3a3FNelNPdWlzR1dnZFNsTFJBOzc2MDpFUDU3a3FNelNPdWlzR1dnZFNsTFJBOzE7dG90YWxfaGl0czo5ODYyMTs%3D\u0026pretty=1",
+  "pageToken": "c2NhbjsyOzc1OTpFUDU3a3FNelNPdWlzR1dnZFNsTFJBOzc2MDpFUDU3a3FNelNPdWlzR1dnZFNsTFJBOzE7dG90YWxfaGl0czo5ODYyMTs=",
+  "totalItems": 3,
+  "items": [
+    {
+      "kind": "store#product",
+      "selfLink": "https://store2.meplato.com/api/v2/catalogs/AD8CCDD5F9/work/products/50763599?pretty=1",
+      "id": "50763599@12",
+      "merchantId": 8,
+      "projectId": 1,
+      "catalogId": 12,
+      "spn": "50763599",
+      "name": "Heller BOHRER SORT. IN KASETTE 9TLG. 273824",
+      "description": "Bohrerkassette\n\n 9-teilig, bestehend aus:\nBeton-/Steinbohrer Power 3000\n4/5/6/8 mm\nHSS-G-Super-Stahlbohrer 900\n3/4/5/6/8 mm",
+      "keywords": null,
+      "categories": [],
+      "eclasses": [
+        {
+          "version": "5.1",
+          "code": "21010100"
+        }
+      ],
+      "unspscs": [],
+      "scalePrices": [],
+      "currency": "EUR",
+      "priceQty": 1,
+      "ou": "PK",
+      "cuPerOu": 1,
+      "cu": "PCE",
+      "leadtime": 5,
+      "quantityMin": 1,
+      "quantityMax": null,
+      "quantityInterval": 1,
+      "taxCode": "0.190000",
+      "conditions": null,
+      "gtin": "4010159273824 ",
+      "bpn": "",
+      "mpn": "4010159273824",
+      "manufacturer": "ITW Heller GmbH",
+      "manufactcode": "",
+      "image": "50763599.jpg",
+      "thumbnail": "",
+      "datasheet": "",
+      "safetysheet": "",
+      "hazmats": [
+        {
+          "kind": "Gefahrgut",
+          "text": "NONE"
+        }
+      ],
+      "matgroup": "",
+      "erpGroupSupplier": "",
+      "extSchemaType": "",
+      "extCategoryId": "",
+      "extCategory": "",
+      "custField1": "",
+      "custField2": "",
+      "custField3": "",
+      "custField4": "",
+      "custField5": "",
+      "references": [
+        {
+          "kind": "others",
+          "spn": "505533",
+          "qty": 1
+        },
+        {
+          "kind": "others",
+          "spn": "518929",
+          "qty": 1
+        },
+        {
+          "kind": "others",
+          "spn": "518930",
+          "qty": 1
+        },
+        {
+          "kind": "others",
+          "spn": "518931",
+          "qty": 1
+        },
+        {
+          "kind": "others",
+          "spn": "50539736",
+          "qty": 1
+        },
+        {
+          "kind": "others",
+          "spn": "50539771",
+          "qty": 1
+        },
+        {
+          "kind": "others",
+          "spn": "50581235",
+          "qty": 1
+        },
+        {
+          "kind": "others",
+          "spn": "50765466",
+          "qty": 1
+        }
+      ],
+      "features": [],
+      "availability": {
+        "qty": 0
+      },
+      "messages": [],
+      "tags": null,
+      "imageURL": "https://store2.meplato.com/abc-elektronik/media?file=50763599.jpg\u0026h=230\u0026w=330",
+      "thumbnailURL": "https://store2.meplato.com/abc-elektronik/media?file=50763599.jpg\u0026h=90\u0026w=90",
+      "price": 10.92,
+      "extProductId": "50763599@12",
+      "mode": "Created",
+      "created": "2015-03-20T13:11:02Z",
+      "updated": "2015-03-20T13:11:02Z"
+    },
+    {
+      "kind": "store#product",
+      "selfLink": "https://store2.meplato.com/api/v2/catalogs/AD8CCDD5F9/work/products/50763601?pretty=1",
+      "id": "50763601@12",
+      "merchantId": 8,
+      "projectId": 1,
+      "catalogId": 12,
+      "spn": "50763601",
+      "name": "Heller QUICK-BIT KASS. 5TLG. HOLZ 265690",
+      "description": "QuickBit®-Satz Holz\n\n 5-teilig\n\n Inhalt: 3, 4, 5, 6, 8 mm",
+      "keywords": null,
+      "categories": [],
+      "eclasses": [
+        {
+          "version": "5.1",
+          "code": "21040190"
+        }
+      ],
+      "unspscs": [],
+      "scalePrices": [],
+      "currency": "EUR",
+      "priceQty": 1,
+      "ou": "PK",
+      "cuPerOu": 1,
+      "cu": "PCE",
+      "leadtime": 5,
+      "quantityMin": 1,
+      "quantityMax": null,
+      "quantityInterval": 1,
+      "taxCode": "0.190000",
+      "conditions": null,
+      "gtin": "4010159265690 ",
+      "bpn": "",
+      "mpn": "4010159265690",
+      "manufacturer": "ITW Heller GmbH",
+      "manufactcode": "",
+      "image": "50763601.jpg",
+      "thumbnail": "",
+      "datasheet": "",
+      "safetysheet": "",
+      "hazmats": [
+        {
+          "kind": "Gefahrgut",
+          "text": "NONE"
+        }
+      ],
+      "matgroup": "",
+      "erpGroupSupplier": "",
+      "extSchemaType": "",
+      "extCategoryId": "",
+      "extCategory": "",
+      "custField1": "",
+      "custField2": "",
+      "custField3": "",
+      "custField4": "",
+      "custField5": "",
+      "references": [
+        {
+          "kind": "others",
+          "spn": "505533",
+          "qty": 1
+        },
+        {
+          "kind": "others",
+          "spn": "518929",
+          "qty": 1
+        },
+        {
+          "kind": "others",
+          "spn": "518930",
+          "qty": 1
+        },
+        {
+          "kind": "others",
+          "spn": "518931",
+          "qty": 1
+        },
+        {
+          "kind": "others",
+          "spn": "50539736",
+          "qty": 1
+        },
+        {
+          "kind": "others",
+          "spn": "50539771",
+          "qty": 1
+        },
+        {
+          "kind": "others",
+          "spn": "50581235",
+          "qty": 1
+        },
+        {
+          "kind": "others",
+          "spn": "50765466",
+          "qty": 1
+        }
+      ],
+      "features": [],
+      "availability": {
+        "qty": 0
+      },
+      "messages": [],
+      "tags": null,
+      "imageURL": "https://store2.meplato.com/abc-elektronik/media?file=50763601.jpg\u0026h=230\u0026w=330",
+      "thumbnailURL": "https://store2.meplato.com/abc-elektronik/media?file=50763601.jpg\u0026h=90\u0026w=90",
+      "price": 11.68,
+      "extProductId": "50763601@12",
+      "mode": "Updated",
+      "created": "2015-03-20T13:11:02Z",
+      "updated": "2015-03-20T15:51:32Z"
+    },
+    {
+      "kind": "store#product",
+      "selfLink": "https://store2.meplato.com/api/v2/catalogs/AD8CCDD5F9/work/products/50763603?pretty=1",
+      "id": "50763603@12",
+      "merchantId": 0,
+      "projectId": 0,
+      "catalogId": 0,
+      "spn": "50763603",
+      "name": "",
+      "description": "",
+      "keywords": null,
+      "categories": null,
+      "eclasses": null,
+      "unspscs": null,
+      "currency": "",
+      "country": "",
+      "priceQty": 0,
+      "ou": "",
+      "cuPerOu": 0,
+      "cu": "",
+      "leadtime": null,
+      "quantityMin": null,
+      "quantityMax": null,
+      "quantityInterval": null,
+      "taxCode": "",
+      "taxRate": 0,
+      "conditions": null,
+      "gtin": "",
+      "asin": "",
+      "bpn": "",
+      "mpn": "",
+      "manufacturer": "",
+      "manufactcode": "",
+      "image": "",
+      "thumbnail": "",
+      "datasheet": "",
+      "safetysheet": "",
+      "blobs": null,
+      "hazmats": null,
+      "intrastat": null,
+      "matgroup": "",
+      "erpGroupSupplier": "",
+      "extSchemaType": "",
+      "extCategoryId": "",
+      "extCategory": "",
+      "extProductId": "",
+      "multiSupplierId": "",
+      "multiSupplierName": "",
+      "custField1": "",
+      "custField2": "",
+      "custField3": "",
+      "custField4": "",
+      "custField5": "",
+      "custFields": null,
+      "references": null,
+      "features": null,
+      "availability": null,
+      "messages": null,
+      "tags": null,
+      "excluded": false,
+      "catalogManaged": false,
+      "price": 0,
+      "mode": "Deleted",
+      "created": "0001-01-01T00:00:00Z",
+      "updated": "0001-01-01T00:00:00Z"
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds the `version` and `mode` parameters to the `scroll` request. With the new version of the Store API (2.1.8), provided archives are enabled for the merchant, this enables the client to download:
- a full older version of a catalog
- a differential download from version `n-1` to `n`

Close #3