### PR TITLE
Delete .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,0 @@
-language: php
-php:
-  - '7.1'
-  # - nightly
-before_script: composer install


### PR DESCRIPTION
Since we moved to GitHub Actions and want to cancel our Travis-CI plan, we want to delete all `.travis.yml` files.